### PR TITLE
`collections.Hashable` -> `collections.abc.Hashable`.

### DIFF
--- a/fiddle/experimental/serialization.py
+++ b/fiddle/experimental/serialization.py
@@ -593,7 +593,7 @@ class Serialization:
         output = self._pyref(value)
       elif id(value) in _serialization_constants_by_id:
         output = _serialization_constants_by_id[id(value)].to_pyref()
-      elif (isinstance(value, collections.Hashable) and
+      elif (isinstance(value, collections.abc.Hashable) and
             value in _serialization_constants_by_value):
         output = _serialization_constants_by_value[value].to_pyref()
       else:


### PR DESCRIPTION
`collections.Hashable` was deprecated in Py3.3. Instead, you should use `collections.abc.Hashable`. This change does that.