### PR TITLE
Drop py3.7.

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ https://github.com/$$YOUR_USERNAME$$/fiddle`.
 > Note: if you're developing on a mac, you'll need xcode installed. (Required
 > for PyType.)
 
-1. Install Python (>= 3.7) locally.
+1. Install Python (>= 3.8) locally.
 2. Navigate to the directory containing your local clone of the git
    repository. (To ensure you're in the right directory, if you type
    `ls | grep CONTRIBUTING.md`, you should see this file listed.)

--- a/fiddle/arg_factory_test.py
+++ b/fiddle/arg_factory_test.py
@@ -90,11 +90,9 @@ class ArgFactoryPartialTest(parameterized.TestCase):
     self.assertEqual(p(arg1=1, arg2=2), (1, 2, 0, None))
     self.assertEqual(p(arg1=5), (5, 'counter_2', 0, None))
 
-  @absltest.skip('Enable this after dropping pyhon 3.7 support')
   def test_positional_only_args(self):
 
-    def f(x, **kwargs):
-      # Use (x, /, **kwargs) when test is enabled.
+    def f(x, /, **kwargs):
       return x, kwargs
 
     # Note: `x` is passed in kwargs, and doesn't go to the positional-only
@@ -149,7 +147,6 @@ class ArgFactoryPartialTest(parameterized.TestCase):
     self.assertIsNot(a.children, b.children)  # child list is not shared
     self.assertIsNot(a.children[0], b.children[0])  # child not shared
 
-  @absltest.skip('Enable this after dropping pyhon 3.7 support')
   def test_param_named_self(self):
     # Note: this test succeeds because _InvokeArgFactoryWrapper.__call__
     # declares `self` as a positional-only parameter.  Otherwise, __call__
@@ -308,7 +305,6 @@ class DefaultFactoryTest(parameterized.TestCase):
     self.assertIsNot(a.children, b.children)  # child list is not shared
     self.assertIsNot(a.children[0], b.children[0])  # child not shared
 
-  @absltest.skip('Enable this after dropping pyhon 3.7 support')
   def test_no_multiple_value_errors(self):
     # Check that all parameter names are supported, including names such
     # as `self` and `func` that are used in the signature of the constructor
@@ -428,8 +424,8 @@ class DefaultFactoryTest(parameterized.TestCase):
     self.assertEqual(f(1, 2), (1, 2))
 
   def test_no_defaults_for_varargs(self):
-    with self.assertRaisesRegex(ValueError,
-                                r'too many values to unpack \(expected 1'):
+    with self.assertRaisesRegex(
+        TypeError, r'takes 2 positional arguments but 3 were given'):
       arg_factory.CallableWithDefaultFactories(varargs_fn, list)  # pytype: disable=wrong-arg-count
 
   def test_no_defaults_for_var_kwargs(self):

--- a/fiddle/config.py
+++ b/fiddle/config.py
@@ -108,7 +108,7 @@ class Buildable(Generic[T], metaclass=abc.ABCMeta):
   __argument_tags__: Dict[str, Set[tag_type.TagType]]
   _has_var_keyword: bool
 
-  def __init__(self, fn_or_cls: Union['Buildable', TypeOrCallableProducingT],
+  def __init__(self, fn_or_cls: Union['Buildable', TypeOrCallableProducingT], /,
                *args, **kwargs):
     """Initialize for ``fn_or_cls``, optionally specifying parameters.
 
@@ -170,7 +170,7 @@ class Buildable(Generic[T], metaclass=abc.ABCMeta):
     )
 
   @abc.abstractmethod
-  def __build__(self, *args, **kwargs):
+  def __build__(self, /, *args, **kwargs):
     """Builds output for this instance; see subclasses for details."""
     raise NotImplementedError()
 
@@ -668,7 +668,7 @@ class Config(Generic[T], Buildable[T]):
   __fn_or_cls__: TypeOrCallableProducingT
   __signature__: inspect.Signature
 
-  def __build__(self, *args, **kwargs):
+  def __build__(self, /, *args, **kwargs):
     """Builds this ``Config`` for the given ``args`` and ``kwargs``.
 
     This method is called during `build` to get the output for this `Config`.
@@ -866,7 +866,7 @@ class Partial(Generic[T], Buildable[T]):
   # NOTE(b/201159339): We currently need to repeat this annotation for pytype.
   __fn_or_cls__: TypeOrCallableProducingT
 
-  def __build__(self, *args, **kwargs):
+  def __build__(self, /, *args, **kwargs):
     """Builds this ``Partial`` for the given ``args`` and ``kwargs``.
 
     This method is called during ``build`` to get the output for this
@@ -922,7 +922,7 @@ class ArgFactory(Generic[T], Buildable[T]):
   # NOTE(b/201159339): We currently need to repeat this annotation for pytype.
   __fn_or_cls__: TypeOrCallableProducingT
 
-  def __build__(self, *args, **kwargs):
+  def __build__(self, /, *args, **kwargs):
     if args or kwargs:
       return _BuiltArgFactory(_build_partial(self.__fn_or_cls__, args, kwargs))
     else:
@@ -992,7 +992,7 @@ def update_callable(buildable: Buildable,
                                         buildable.__arguments__)
 
 
-def assign(buildable: Buildable, **kwargs):
+def assign(buildable: Buildable, /, **kwargs):
   """Assigns multiple arguments to ``buildable``.
 
   Although this function does not enable a caller to do something they can't
@@ -1016,7 +1016,7 @@ def assign(buildable: Buildable, **kwargs):
     setattr(buildable, name, value)
 
 
-def copy_with(buildable: Buildable, **kwargs):
+def copy_with(buildable: Buildable, /, **kwargs):
   """Returns a shallow copy of ``buildable`` with updates to arguments.
 
   Args:
@@ -1028,7 +1028,7 @@ def copy_with(buildable: Buildable, **kwargs):
   return buildable
 
 
-def deepcopy_with(buildable: Buildable, **kwargs):
+def deepcopy_with(buildable: Buildable, /, **kwargs):
   """Returns a deep copy of ``buildable`` with updates to arguments.
 
   Note: if any ``Config``'s inside ``buildable`` are shared with ``Config``'s

--- a/fiddle/config_test.py
+++ b/fiddle/config_test.py
@@ -1140,7 +1140,6 @@ class ConfigTest(absltest.TestCase):
       cfg.child.x = 5  # now it's ok to configure child.
       self.assertEqual(fdl.build(cfg), DataclassParent(DataclassChild(5)))
 
-  @absltest.skip('Enable this after dropping pyhon 3.7 support')
   def test_config_for_fn_with_special_arg_names(self):
     # The reason that these tests pass is that we use positional-only
     # parameters for self, etc. in functions such as Config.__build__.

--- a/fiddle/diffing.py
+++ b/fiddle/diffing.py
@@ -912,7 +912,7 @@ class AnyCallable(AnyValue):
   """Object used by `skeleton_from_diff` to encode an unknown callable."""
   __name__ = '*'
 
-  def __call__(self, **kwargs):
+  def __call__(self, /, **kwargs):
     raise ValueError('AnyCallable should not be called.')
 
 

--- a/fiddle/experimental/auto_config.py
+++ b/fiddle/experimental/auto_config.py
@@ -74,10 +74,10 @@ class AutoConfig:
       else:
         object.__setattr__(self, name, value)
 
-  def __call__(self, *args, **kwargs) -> Any:
+  def __call__(self, /, *args, **kwargs) -> Any:
     return self.func(*args, **kwargs)
 
-  def as_buildable(self, *args, **kwargs) -> config.Buildable:
+  def as_buildable(self, /, *args, **kwargs) -> config.Buildable:
     return self.buildable_func(*args, **kwargs)
 
   def __get__(self, obj, objtype=None):
@@ -125,10 +125,10 @@ class _BoundAutoConfig:
       # Pass through extra things on the thing we wrapped.
       return getattr(super().__getattribute__('auto_config'), name)
 
-  def __call__(self, *args, **kwargs) -> Any:
+  def __call__(self, /, *args, **kwargs) -> Any:
     return self.auto_config.func(self.obj, *args, **kwargs)
 
-  def as_buildable(self, *args, **kwargs) -> config.Buildable:
+  def as_buildable(self, /, *args, **kwargs) -> config.Buildable:
     return self.auto_config.buildable_func(self.obj, *args, **kwargs)
 
   @property
@@ -479,7 +479,7 @@ def auto_config(
   if experimental_exemption_policy is None:
     experimental_exemption_policy = auto_config_policy.latest
 
-  def auto_config_call_handler(fn_or_cls, *args, **kwargs):
+  def auto_config_call_handler(fn_or_cls, /, *args, **kwargs):
     """Handles calls in auto_config'ed functions.
 
     This intercepts calls in an auto-configed function, and determines whether

--- a/fiddle/experimental/auto_config_test.py
+++ b/fiddle/experimental/auto_config_test.py
@@ -745,7 +745,6 @@ class AutoConfigTest(parameterized.TestCase, test_util.TestCase):
     # But if we access it via the class, we get the (unbound) AutoConfig:
     self.assertIsInstance(SampleClass.autoconfig_method, auto_config.AutoConfig)
 
-  @absltest.skip('Enable this after dropping pyhon 3.7 support')
   def test_can_pass_self_as_keyword(self):
     x = SampleClass(1, 2)
     self.assertEqual(

--- a/fiddle/experimental/dict_config.py
+++ b/fiddle/experimental/dict_config.py
@@ -27,7 +27,7 @@ def _kwargs_to_dict(**kwargs):
 class DictConfig(config.Config):
   """A Config instance that builds a `dict` accepting any keys/values."""
 
-  def __init__(self, *args, **kwargs):
+  def __init__(self, /, *args, **kwargs):
     super().__init__(_kwargs_to_dict, *args, **kwargs)
 
   @classmethod

--- a/fiddle/experimental/dict_config_test.py
+++ b/fiddle/experimental/dict_config_test.py
@@ -81,7 +81,6 @@ class DictConfigTest(absltest.TestCase):
       cfg2.y = 'def'
       self.assertNotEqual(cfg1, cfg2)
 
-  @absltest.skip('Enable this after dropping pyhon 3.7 support')
   def test_key_named_self(self):
     cfg = dict_config.DictConfig(self=2)  # pytype: disable=duplicate-keyword-argument
     self.assertEqual(fdl.build(cfg), {'self': 2})

--- a/fiddle/experimental/namespace_config.py
+++ b/fiddle/experimental/namespace_config.py
@@ -28,7 +28,7 @@ def _kwargs_to_namespace(**kwargs: Any) -> types.SimpleNamespace:
 class NamespaceConfig(config.Config):
   """A Config that builds a `types.SimpleNamespace` accepting all arg names."""
 
-  def __init__(self, *args, **kwargs):
+  def __init__(self, /, *args, **kwargs):
     super().__init__(_kwargs_to_namespace, *args, **kwargs)
 
   @classmethod

--- a/fiddle/experimental/namespace_config_test.py
+++ b/fiddle/experimental/namespace_config_test.py
@@ -75,7 +75,6 @@ class NamespaceConfigTest(absltest.TestCase):
       cfg2.y = 'def'
       self.assertNotEqual(cfg1, cfg2)
 
-  @absltest.skip('Enable this after dropping pyhon 3.7 support')
   def test_key_named_self(self):
     cfg = namespace_config.NamespaceConfig()
     cfg.self = 2

--- a/fiddle/lingvo/lingvo_config.py
+++ b/fiddle/lingvo/lingvo_config.py
@@ -104,7 +104,7 @@ class LingvoParamsAdapter:
       self.is_nested = False
     self.__signature__ = _make_signature_from_lingvo_params(self.params)
 
-  def __call__(self, *args, **kwargs):
+  def __call__(self, /, *args, **kwargs):
     if args:
       raise AssertionError(
           f"*args not empty, please file a bug with repro steps; args: {args}.")
@@ -129,7 +129,7 @@ class LingvoConfig(config.Config):
   """
 
   def __init__(self, params_or_cls: Union["LingvoConfig", LingvoParamsAdapter,
-                                          ParamInitable, hyperparams.Params],
+                                          ParamInitable, hyperparams.Params], /,
                *args, **kwargs):
     if (isinstance(params_or_cls, LingvoParamsAdapter) or
         isinstance(params_or_cls, LingvoConfig)):

--- a/fiddle/selectors.py
+++ b/fiddle/selectors.py
@@ -52,7 +52,7 @@ class Selection(metaclass=abc.ABCMeta):
     raise NotImplementedError()
 
   @abc.abstractmethod
-  def set(self, **kwargs) -> None:
+  def set(self, /, **kwargs) -> None:
     """Sets attributes on nodes matching this selection.
 
     Args:
@@ -160,7 +160,7 @@ class NodeSelection(Selection):
     mutate_buildable.move_buildable_internals(
         source=new_config, destination=self.cfg)
 
-  def set(self, **kwargs) -> None:
+  def set(self, /, **kwargs) -> None:
     """Sets multiple attributes on nodes matching this selection.
 
     Args:
@@ -213,7 +213,7 @@ class TagSelection(Selection):
         "To iterate through values of a TagSelection, use __iter__ instead "
         "of get().")
 
-  def set(self, **kwargs) -> None:
+  def set(self, /, **kwargs) -> None:
     raise NotImplementedError(
         "You can't set named attributes on tagged values, you can only replace "
         "them. Please call replace() instead of set().")


### PR DESCRIPTION
Fiddle intends to drop support for Python 3.7 as it is beyond EoL. Additionally, by dropping Py3.7, we can better support all sorts of argument names.