### PR TITLE
Fixes sphinx warnings: enable auto-generated headers & syntax fixes.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,3 +98,6 @@ html_favicon = '_static/favicon.png'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Enable auto-generation of anchors for headings in markdown files.
+myst_heading_anchors = 3

--- a/fiddle/tagging.py
+++ b/fiddle/tagging.py
@@ -152,7 +152,7 @@ def TaggedValue(  # pylint: disable=invalid-name
     tags: Collection[TagType],
     default: Union[NoValue, T] = NO_VALUE,
 ) -> TaggedValueCls[T]:
-  """Declares a value annotated with a set of `Tag`s.
+  """Declares a value annotated with a set of ``Tag``'s.
 
   This is now basically a fdl.Config(lambda value: value) configuration, since
   tags can be set on any field.
@@ -198,7 +198,7 @@ def list_tags(
   """Lists all tags in a buildable.
 
   Args:
-    root: The root of a DAG of `Buildable`s.
+    root: The root of a DAG of ``Buildable``'s.
     add_superclasses: For tags that inherit from other tags, add the
       superclasses as well.
 


### PR DESCRIPTION
This PR should actually fix the final 3 warnings blocking docs generation, as verified by deleting the build directory and re-running the docs generation process. (This has been verified as the final errors by matching them up with the errors generated from the readthedocs.io build console.)

The fixes involve:
 1. Ensuring the `#definitions` in-page link works by enabling myst to automatically generate anchors corresponding to each header.
 2. Fixing rst syntax in docstrings.