### PR TITLE
Make tests pass for Python 3.8

### DIFF
--- a/fiddle/codegen/auto_config/naming_test.py
+++ b/fiddle/codegen/auto_config/naming_test.py
@@ -16,6 +16,7 @@
 """Tests for naming."""
 
 import dataclasses
+from typing import Dict
 
 from absl.testing import absltest
 import fiddle as fdl
@@ -33,7 +34,7 @@ class Qux:
 @dataclasses.dataclass(frozen=True)
 class Foo:
   a: int = 0
-  bar: dict[str, Qux] = dataclasses.field(default_factory=dict)
+  bar: Dict[str, Qux] = dataclasses.field(default_factory=dict)
 
 
 def new_path_first_namer():


### PR DESCRIPTION
Support for `dict[key_type, value_type]` was only added in Python 3.9. Instead, `typing.Dict[key_type, value_type]` should be used.