### PR TITLE
Pin `Jinja2` to fix docs build.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@ sphinx-design
 sphinx-remove-toctrees
 jupyter-sphinx>=0.3.2
 myst-nb
+Jinja2<3.1
 
 # Install the Fiddle package itself.
 .[testing]


### PR DESCRIPTION
Without pinning, a default pip install will get Jinja2==3.1.3. But this, unfortunately, results in
https://github.com/sphinx-doc/sphinx/issues/10291

Note: this makes the docs build work for Python 3.9, on Linux/Debian.