### PR TITLE
[Docs] Update build comment to treat warnings as errors.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,5 @@ You can build the docs site locally as follows:
 
 ```bash
 pip install -r docs/requirements.txt
-sphinx-build -b html docs docs/build/html -j auto
+sphinx-build -W -b html docs docs/build/html -j auto
 ```


### PR DESCRIPTION
The readthedocs.io site builds with warnings-as-errors, so this will help ensure local development will catch and debug issues.