### PR TITLE
Fix docs-build warnings.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,5 @@ You can build the docs site locally as follows:
 
 ```bash
 pip install -r docs/requirements.txt
-sphinx-build -b html docs docs/build/html -j auto
+sphinx-build -W -b html docs docs/build/html -j auto
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >=3
+sphinx >4, <5
 sphinx-autodoc-typehints
 sphinx-book-theme>=0.3.3
 sphinx-copybutton>=0.5.0
@@ -6,7 +6,6 @@ sphinx-design
 sphinx-remove-toctrees
 jupyter-sphinx>=0.3.2
 myst-nb
-Jinja2<3.1
 
 # Install the Fiddle package itself.
 .[testing]


### PR DESCRIPTION
Previously, there were warnings introduced due to dependencies not working out properly. These warnings would cause the automated build to fail on readthedocs.io. This change fixes up the versioning requirements so that the docs builds with no warnings, and updates the documentation to encourage the `-W` flag which turns warnings into errors when building locally.