### PR TITLE
fix error when building a Generic type

### DIFF
--- a/fiddle/_src/config_test.py
+++ b/fiddle/_src/config_test.py
@@ -18,6 +18,7 @@
 import copy
 import dataclasses
 import pickle
+import sys
 import threading
 from typing import Any, Dict, Generic, TypeVar
 from absl.testing import absltest
@@ -679,8 +680,9 @@ class ConfigTest(parameterized.TestCase):
     self.assertEqual(cfg1, cfg2)
 
   def test_generic_classes(self):
-    cfg = fdl.Config(GenericClass, 1)
-    self.assertEqual(fdl.build(cfg), GenericClass(1))
+    if sys.version_info >= (3, 9):
+      cfg = fdl.Config(GenericClass, 1)
+      self.assertEqual(fdl.build(cfg), GenericClass(1))
 
     self.assertEqual(fdl.Config(GenericClass).x, 1)
     self.assertEqual(fdl.Config(GenericClass[int]).x, 1)

--- a/fiddle/_src/config_test.py
+++ b/fiddle/_src/config_test.py
@@ -678,7 +678,10 @@ class ConfigTest(parameterized.TestCase):
     cfg2 = fdl.Config(basic_fn, 1, 2, None, kwarg2=None)
     self.assertEqual(cfg1, cfg2)
 
-  def test_default_value_for_generic_classes(self):
+  def test_generic_classes(self):
+    cfg = fdl.Config(GenericClass, 1)
+    self.assertEqual(fdl.build(cfg), GenericClass(1))
+
     self.assertEqual(fdl.Config(GenericClass).x, 1)
     self.assertEqual(fdl.Config(GenericClass[int]).x, 1)
 

--- a/fiddle/_src/signatures.py
+++ b/fiddle/_src/signatures.py
@@ -62,8 +62,6 @@ def _get_signature_uncached(fn_or_cls) -> inspect.Signature:
   # support.
   origin = typing_extensions.get_origin(fn_or_cls)
   fn_or_cls = origin if origin is not None else fn_or_cls
-  if isinstance(fn_or_cls, type) and issubclass(fn_or_cls, Generic):
-    fn_or_cls = fn_or_cls.__init__
 
   try:
     return inspect.signature(fn_or_cls)

--- a/fiddle/_src/signatures.py
+++ b/fiddle/_src/signatures.py
@@ -17,6 +17,7 @@
 
 import dataclasses
 import inspect
+import sys
 from typing import Any, Callable, Dict, Generic, List, Mapping, Optional, Tuple, Type, Union
 import weakref
 import typing_extensions
@@ -62,6 +63,10 @@ def _get_signature_uncached(fn_or_cls) -> inspect.Signature:
   # support.
   origin = typing_extensions.get_origin(fn_or_cls)
   fn_or_cls = origin if origin is not None else fn_or_cls
+  # Workaround a bug in inspect.signature https://github.com/python/cpython/issues/85074
+  if sys.version_info < (3, 9):
+    if isinstance(fn_or_cls, type) and issubclass(fn_or_cls, Generic):
+      fn_or_cls = fn_or_cls.__init__
 
   try:
     return inspect.signature(fn_or_cls)


### PR DESCRIPTION
fix #515 

The added unittest would fail before this PR and now pass. The check `if isinstance(fn_or_cls, type) and issubclass(fn_or_cls, Generic)` is kept as a workaround for python3.8. 


The failure before this PR is:
```
>       return buildable.__build__(*args, **kwargs)
E       TypeError: Config.__build__() got multiple values for argument 'self'
E
E       Fiddle context: failed to construct or call GenericClass at <root> with positional arguments: (), keyword arguments: (self=1).
```